### PR TITLE
Re-introduce a constant specifying the name of Ed25519

### DIFF
--- a/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
@@ -63,7 +63,7 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
 
     public EdDSAPrivateKey(PKCS8EncodedKeySpec spec) throws InvalidKeySpecException {
         this(new EdDSAPrivateKeySpec(decode(spec.getEncoded()),
-                                     EdDSANamedCurveTable.getByName("Ed25519")));
+                                     EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519)));
     }
 
     @Override
@@ -136,7 +136,7 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
      */
     @Override
     public byte[] getEncoded() {
-        if (!edDsaSpec.equals(EdDSANamedCurveTable.getByName("Ed25519")))
+        if (!edDsaSpec.equals(EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519)))
             return null;
         if (seed == null)
             return null;

--- a/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
@@ -59,7 +59,7 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
 
     public EdDSAPublicKey(X509EncodedKeySpec spec) throws InvalidKeySpecException {
         this(new EdDSAPublicKeySpec(decode(spec.getEncoded()),
-                                    EdDSANamedCurveTable.getByName("Ed25519")));
+                                    EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519)));
     }
 
     @Override
@@ -113,7 +113,7 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
      */
     @Override
     public byte[] getEncoded() {
-        if (!edDsaSpec.equals(EdDSANamedCurveTable.getByName("Ed25519")))
+        if (!edDsaSpec.equals(EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519)))
             return null;
         int totlen = 12 + Abyte.length;
         byte[] rv = new byte[totlen];

--- a/src/net/i2p/crypto/eddsa/KeyPairGenerator.java
+++ b/src/net/i2p/crypto/eddsa/KeyPairGenerator.java
@@ -40,7 +40,7 @@ public final class KeyPairGenerator extends KeyPairGeneratorSpi {
     static {
         edParameters = new Hashtable<Integer, AlgorithmParameterSpec>();
 
-        edParameters.put(Integer.valueOf(256), new EdDSAGenParameterSpec("Ed25519"));
+        edParameters.put(Integer.valueOf(256), new EdDSAGenParameterSpec(EdDSANamedCurveTable.ED_25519));
     }
 
     public void initialize(int keysize, SecureRandom random) {

--- a/src/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTable.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTable.java
@@ -26,6 +26,8 @@ import net.i2p.crypto.eddsa.math.ed25519.Ed25519ScalarOps;
  *
  */
 public class EdDSANamedCurveTable {
+    public static final String ED_25519 = "Ed25519";
+
     private static final Field ed25519field = new Field(
                     256, // b
                     Utils.hexToBytes("edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f"), // q
@@ -36,7 +38,7 @@ public class EdDSANamedCurveTable {
             ed25519field.fromByteArray(Utils.hexToBytes("b0a00e4a271beec478e42fad0618432fa7d7fb3d99004d2b0bdfc14f8024832b"))); // I
 
     private static final EdDSANamedCurveSpec ed25519 = new EdDSANamedCurveSpec(
-            "Ed25519",
+            ED_25519,
             ed25519curve,
             "SHA-512", // H
             new Ed25519ScalarOps(), // l

--- a/test/net/i2p/crypto/eddsa/EdDSAEngineTest.java
+++ b/test/net/i2p/crypto/eddsa/EdDSAEngineTest.java
@@ -46,7 +46,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testSign() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         //Signature sgr = Signature.getInstance("EdDSA", "I2P");
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
 
@@ -64,7 +64,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testVerify() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         //Signature sgr = Signature.getInstance("EdDSA", "I2P");
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         for (Ed25519TestVectors.TestTuple testCase : Ed25519TestVectors.testCases) {
@@ -84,7 +84,7 @@ public class EdDSAEngineTest {
      */
     @Test
     public void testVerifyWrongSigLength() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         //Signature sgr = Signature.getInstance("EdDSA", "I2P");
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
@@ -100,7 +100,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testSignResetsForReuse() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPrivateKeySpec privKey = new EdDSAPrivateKeySpec(TEST_SEED, spec);
         PrivateKey sKey = new EdDSAPrivateKey(privKey);
@@ -117,7 +117,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testVerifyResetsForReuse() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
         PublicKey vKey = new EdDSAPublicKey(pubKey);
@@ -134,7 +134,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testSignOneShotMode() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPrivateKeySpec privKey = new EdDSAPrivateKeySpec(TEST_SEED, spec);
         PrivateKey sKey = new EdDSAPrivateKey(privKey);
@@ -148,7 +148,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testVerifyOneShotMode() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
         PublicKey vKey = new EdDSAPublicKey(pubKey);
@@ -162,7 +162,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testSignOneShotModeMultipleUpdates() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPrivateKeySpec privKey = new EdDSAPrivateKeySpec(TEST_SEED, spec);
         PrivateKey sKey = new EdDSAPrivateKey(privKey);
@@ -178,7 +178,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testVerifyOneShotModeMultipleUpdates() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         PublicKey vKey = new EdDSAPublicKey(pubKey);
@@ -194,7 +194,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testSignOneShot() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         EdDSAPrivateKeySpec privKey = new EdDSAPrivateKeySpec(TEST_SEED, spec);
         EdDSAEngine sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         PrivateKey sKey = new EdDSAPrivateKey(privKey);
@@ -205,7 +205,7 @@ public class EdDSAEngineTest {
 
     @Test
     public void testVerifyOneShot() throws Exception {
-        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
         EdDSAEngine sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         PublicKey vKey = new EdDSAPublicKey(pubKey);

--- a/test/net/i2p/crypto/eddsa/math/ConstantsTest.java
+++ b/test/net/i2p/crypto/eddsa/math/ConstantsTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
  *
  */
 public class ConstantsTest {
-    static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName("Ed25519");
+    static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
     static final Curve curve = ed25519.getCurve();
 
     static final FieldElement ZERO = curve.getField().ZERO;

--- a/test/net/i2p/crypto/eddsa/math/GroupElementTest.java
+++ b/test/net/i2p/crypto/eddsa/math/GroupElementTest.java
@@ -34,7 +34,7 @@ public class GroupElementTest {
     static final byte[] BYTES_TENZERO = Utils.hexToBytes("0000000000000000000000000000000000000000000000000000000000000000");
     static final byte[] BYTES_ONETEN = Utils.hexToBytes("0a00000000000000000000000000000000000000000000000000000000000080");
 
-    static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName("Ed25519");
+    static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
     static final Curve curve = ed25519.getCurve();
 
     static final FieldElement ZERO = curve.getField().ZERO;

--- a/test/net/i2p/crypto/eddsa/math/MathUtils.java
+++ b/test/net/i2p/crypto/eddsa/math/MathUtils.java
@@ -26,7 +26,7 @@ import java.security.SecureRandom;
 public class MathUtils {
     private static final int[] exponents = {0, 26, 26 + 25, 2*26 + 25, 2*26 + 2*25, 3*26 + 2*25, 3*26 + 3*25, 4*26 + 3*25, 4*26 + 4*25, 5*26 + 4*25};
     private static final SecureRandom random = new SecureRandom();
-    private static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName("Ed25519");
+    private static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
     private static final Curve curve = ed25519.getCurve();
     private static final BigInteger d = new BigInteger("-121665").multiply(new BigInteger("121666").modInverse(getQ()));
     private static final BigInteger groupOrder = BigInteger.ONE.shiftLeft(252).add(new BigInteger("27742317777372353535851937790883648493"));

--- a/test/net/i2p/crypto/eddsa/math/PrecomputationTestVectors.java
+++ b/test/net/i2p/crypto/eddsa/math/PrecomputationTestVectors.java
@@ -27,7 +27,7 @@ public class PrecomputationTestVectors {
     static GroupElement[] testDblPrecmp = getDoublePrecomputation("baseDblPrecmp");
 
     public static GroupElement[][] getPrecomputation(String fileName) {
-        EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Curve curve = ed25519.getCurve();
         Field field = curve.getField();
         GroupElement[][] precmp = new GroupElement[32][8];
@@ -70,7 +70,7 @@ public class PrecomputationTestVectors {
     }
 
     public static GroupElement[] getDoublePrecomputation(String fileName) {
-        EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName("Ed25519");
+        EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Curve curve = ed25519.getCurve();
         Field field = curve.getField();
         GroupElement[] dblPrecmp = new GroupElement[8];

--- a/test/net/i2p/crypto/eddsa/math/bigint/BigIntegerScalarOpsTest.java
+++ b/test/net/i2p/crypto/eddsa/math/bigint/BigIntegerScalarOpsTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  */
 public class BigIntegerScalarOpsTest {
 
-    static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName("Ed25519");
+    static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
     static final Field ed25519Field = ed25519.getCurve().getField();
 
     /**

--- a/test/net/i2p/crypto/eddsa/spec/EdDSAPrivateKeySpecTest.java
+++ b/test/net/i2p/crypto/eddsa/spec/EdDSAPrivateKeySpecTest.java
@@ -14,6 +14,7 @@ package net.i2p.crypto.eddsa.spec;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import net.i2p.crypto.eddsa.Utils;
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,7 +29,7 @@ public class EdDSAPrivateKeySpecTest {
     static final byte[] ZERO_H = Utils.hexToBytes("5046adc1dba838867b2bbbfdd0c3423e58b57970b5267a90f57960924a87f1960a6a85eaa642dac835424b5d7c8d637c00408c7a73da672b7f498521420b6dd3");
     static final byte[] ZERO_PK = Utils.hexToBytes("3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29");
 
-    static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName("Ed25519");
+    static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
 
     @Rule
     public ExpectedException exception = ExpectedException.none();


### PR DESCRIPTION
This partially reverts commit 7dfc91cb7a4654110d25491bd4de1faefbada3bb, with a
more usable constant name. The contract is unchanged - users can still specify
the string "Ed25519" in any case, and will obtain the curve.

Closes #43.