### PR TITLE
Add an Automatic-Module-Name entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,9 @@
             <Private-Package>
               net.i2p.crypto.eddsa.math.*
             </Private-Package>
+            <Automatic-Module-Name>
+              net.i2p.crypto.eddsa
+            </Automatic-Module-Name>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
This adds an Automatic-Module-Name entry to the jar to give a stable
name that can be used in a "requires" clause in a JPMS module. The
name used is "net.i2p.crypto.eddsa" to match the symbolic name used
in the OSGi metadata.