### PR TITLE
De-contend code paths to support greater throughput in multi-threaded environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Download the latest .jar from the releases tab and place it in your classpath.
 Gradle users:
 
 ```
-compile 'net.i2p.crypto:eddsa:0.2.0'
+compile 'net.i2p.crypto:eddsa:0.3.0'
 ```
 
 The code requires Java 6 (for e.g. the `Arrays.copyOfRange()` calls in `EdDSAEngine.engineVerify()`).
@@ -63,6 +63,14 @@ For ease of following, here are the main methods in ref10 and their equivalents 
 
 Important changes
 -----------------
+
+### 0.3.0
+
+- The library has been extensively profiled for contention issues in a multi-threaded environment.  The only remaining potential
+contention is in `EdDSANamedCurveTable.defineCurve()`, which will be rarely called.
+- The public constant for `Ed25519` has returned as `ED_25519` to avoid repeated lookups in `EdDSAPublicKey.getEncoded()`.
+- `GroupElement` is now completely immutable and all fields final to avoid the need for `synchronized` blocks over mutable fields.
+This required some new constructors and paths to construction.
 
 ### 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,14 @@ Important changes
 
 - The library has been extensively profiled for contention issues in a multi-threaded environment.  The only remaining potential
 contention is in `EdDSANamedCurveTable.defineCurve()`, which will be rarely called.
-- The public constant for `Ed25519` has returned as `ED_25519` to avoid repeated lookups in `EdDSAPublicKey.getEncoded()`.
+- The public constant for the curve name has returned as `ED_25519` and the curve specification has a public constant
+`ED_25519_CURVE_SPEC` to avoid repeated lookups when converting to and from encoded form for the public or private keys.
 - `GroupElement` is now completely immutable and all fields final to avoid the need for `synchronized` blocks over mutable fields.
 This required some new constructors and paths to construction.
+- `EdDSAPublicKeySpec.getNegativeA()` and `EdDSAPublicKey.getNegativeA()` now evaluate lazily, taking advantage of the 
+immutability of `GroupElement.negate()` which boosts the performance of the public key constructor when the key is just 
+being passed around rather than used. 
+- Support for X509Key wrapped EdDSA public keys.
 
 ### 0.2.0
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.i2p.crypto</groupId>
   <artifactId>eddsa</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <name>EdDSA-Java</name>
   <packaging>bundle</packaging>
   <description>Implementation of EdDSA in Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
           <charset>UTF-8</charset>
           <docencoding>UTF-8</docencoding>
           <encoding>UTF-8</encoding>
+          <additionalparam>--allow-script-in-comments</additionalparam>
           <header>&lt;script type='text/x-mathjax-config'&gt;
   MathJax.Hub.Config({
     tex2jax: {

--- a/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
@@ -82,10 +82,10 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
      * This implements the following specs:
      *<ul><li>
      * General encoding: https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
-     *</li></li>
+     *</li><li>
      * Key encoding: https://tools.ietf.org/html/rfc8032
      *</li></ul>
-     *</p><p>
+     *<p>
      * This encodes the seed. It will return null if constructed from
      * a spec which was directly constructed from H, in which case seed is null.
      *</p><p>

--- a/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
@@ -63,7 +63,7 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
 
     public EdDSAPrivateKey(PKCS8EncodedKeySpec spec) throws InvalidKeySpecException {
         this(new EdDSAPrivateKeySpec(decode(spec.getEncoded()),
-                                     EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519)));
+                                     EdDSANamedCurveTable.ED_25519_CURVE_SPEC));
     }
 
     @Override
@@ -136,7 +136,7 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
      */
     @Override
     public byte[] getEncoded() {
-        if (!edDsaSpec.equals(EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519)))
+        if (!edDsaSpec.equals(EdDSANamedCurveTable.ED_25519_CURVE_SPEC))
             return null;
         if (seed == null)
             return null;

--- a/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
@@ -78,10 +78,10 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
      * This implements the following specs:
      *<ul><li>
      * General encoding: https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
-     *</li></li>
+     *</li><li>
      * Key encoding: https://tools.ietf.org/html/rfc8032
      *</li></ul>
-     *</p><p>
+     *<p>
      * For keys in older formats, decoding and then re-encoding is sufficient to
      * migrate them to the canonical encoding.
      *</p>

--- a/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
@@ -40,7 +40,7 @@ import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
 public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     private static final long serialVersionUID = 9837459837498475L;
     private final GroupElement A;
-    private final GroupElement Aneg;
+    private GroupElement Aneg = null;
     private final byte[] Abyte;
     private final EdDSAParameterSpec edDsaSpec;
 
@@ -52,7 +52,6 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
 
     public EdDSAPublicKey(EdDSAPublicKeySpec spec) {
         this.A = spec.getA();
-        this.Aneg = spec.getNegativeA();
         this.Abyte = this.A.toByteArray();
         this.edDsaSpec = spec.getParams();
     }
@@ -250,7 +249,13 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     }
 
     public GroupElement getNegativeA() {
-        return Aneg;
+        // Only read Aneg once, otherwise read re-ordering might occur between here and return. Requires all GroupElement's fields to be final.
+        GroupElement ourAneg = Aneg;
+        if(ourAneg == null) {
+            ourAneg = A.negate();
+            Aneg = ourAneg;
+        }
+        return ourAneg;
     }
 
     public byte[] getAbyte() {

--- a/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
@@ -58,7 +58,7 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
 
     public EdDSAPublicKey(X509EncodedKeySpec spec) throws InvalidKeySpecException {
         this(new EdDSAPublicKeySpec(decode(spec.getEncoded()),
-                                    EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519)));
+                                    EdDSANamedCurveTable.ED_25519_CURVE_SPEC));
     }
 
     @Override
@@ -112,7 +112,7 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
      */
     @Override
     public byte[] getEncoded() {
-        if (!edDsaSpec.equals(EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519)))
+        if (!edDsaSpec.equals(EdDSANamedCurveTable.ED_25519_CURVE_SPEC))
             return null;
         int totlen = 12 + Abyte.length;
         byte[] rv = new byte[totlen];

--- a/src/net/i2p/crypto/eddsa/math/Curve.java
+++ b/src/net/i2p/crypto/eddsa/math/Curve.java
@@ -28,6 +28,7 @@ public class Curve implements Serializable {
 
     private final GroupElement zeroP2;
     private final GroupElement zeroP3;
+    private final GroupElement zeroP3PrecomputedDouble;
     private final GroupElement zeroPrecomp;
 
     public Curve(Field f, byte[] d, FieldElement I) {
@@ -39,7 +40,8 @@ public class Curve implements Serializable {
         FieldElement zero = f.ZERO;
         FieldElement one = f.ONE;
         zeroP2 = GroupElement.p2(this, zero, one, one);
-        zeroP3 = GroupElement.p3(this, zero, one, one, zero);
+        zeroP3 = GroupElement.p3(this, zero, one, one, zero, false);
+        zeroP3PrecomputedDouble = GroupElement.p3(this, zero, one, one, zero, true);
         zeroPrecomp = GroupElement.precomp(this, one, one, zero);
     }
 
@@ -65,6 +67,8 @@ public class Curve implements Serializable {
             return zeroP2;
         case P3:
             return zeroP3;
+        case P3PrecomputedDouble:
+            return zeroP3PrecomputedDouble;
         case PRECOMP:
             return zeroPrecomp;
         default:
@@ -73,9 +77,7 @@ public class Curve implements Serializable {
     }
 
     public GroupElement createPoint(byte[] P, boolean precompute) {
-        GroupElement ge = new GroupElement(this, P);
-        if (precompute)
-            ge.precompute(true);
+        GroupElement ge = new GroupElement(this, P, precompute);
         return ge;
     }
 

--- a/src/net/i2p/crypto/eddsa/math/GroupElement.java
+++ b/src/net/i2p/crypto/eddsa/math/GroupElement.java
@@ -50,7 +50,7 @@ public class GroupElement implements Serializable {
         P2,
         /** Extended ($P^3$): $(X:Y:Z:T)$ satisfying $x=X/Z, y=Y/Z, XY=ZT$ */
         P3,
-        /** P3 but also populate dblPrecmp */
+        /** Can only be requested.  Results in P3 representation but also populates dblPrecmp. */
         P3PrecomputedDouble,
         /** Completed ($P \times P$): $((X:Z),(Y:T))$ satisfying $x=X/Z, y=Y/T$ */
         P1P1,
@@ -74,11 +74,30 @@ public class GroupElement implements Serializable {
             final FieldElement X,
             final FieldElement Y,
             final FieldElement Z) {
-        return new GroupElement(curve, Representation.P2, X, Y, Z, null, false);
+        return new GroupElement(curve, Representation.P2, X, Y, Z, null);
     }
 
     /**
-     * Creates a new group element in P3 representation.
+     * Creates a new group element in P3 representation, without pre-computation.
+     *
+     * @param curve The curve.
+     * @param X The $X$ coordinate.
+     * @param Y The $Y$ coordinate.
+     * @param Z The $Z$ coordinate.
+     * @param T The $T$ coordinate.
+     * @return The group element in P3 representation.
+     */
+    public static GroupElement p3(
+            final Curve curve,
+            final FieldElement X,
+            final FieldElement Y,
+            final FieldElement Z,
+            final FieldElement T) {
+        return p3(curve, X, Y, Z, T, false);
+    }
+
+    /**
+     * Creates a new group element in P3 representation, potentially with pre-computation.
      *
      * @param curve The curve.
      * @param X The $X$ coordinate.
@@ -114,7 +133,7 @@ public class GroupElement implements Serializable {
             final FieldElement Y,
             final FieldElement Z,
             final FieldElement T) {
-        return new GroupElement(curve, Representation.P1P1, X, Y, Z, T, false);
+        return new GroupElement(curve, Representation.P1P1, X, Y, Z, T);
     }
 
     /**
@@ -131,7 +150,7 @@ public class GroupElement implements Serializable {
             final FieldElement ypx,
             final FieldElement ymx,
             final FieldElement xy2d) {
-        return new GroupElement(curve, Representation.PRECOMP, ypx, ymx, xy2d, null, false);
+        return new GroupElement(curve, Representation.PRECOMP, ypx, ymx, xy2d, null);
     }
 
     /**
@@ -150,7 +169,7 @@ public class GroupElement implements Serializable {
             final FieldElement YmX,
             final FieldElement Z,
             final FieldElement T2d) {
-        return new GroupElement(curve, Representation.CACHED, YpX, YmX, Z, T2d, false);
+        return new GroupElement(curve, Representation.CACHED, YpX, YmX, Z, T2d);
     }
 
     /**
@@ -200,7 +219,27 @@ public class GroupElement implements Serializable {
     final GroupElement[] dblPrecmp;
 
     /**
-     * Creates a group element for a curve.
+     * Creates a group element for a curve, without any pre-computation.
+     *
+     * @param curve The curve.
+     * @param repr The representation used to represent the group element.
+     * @param X The $X$ coordinate.
+     * @param Y The $Y$ coordinate.
+     * @param Z The $Z$ coordinate.
+     * @param T The $T$ coordinate.
+     */
+    public GroupElement(
+            final Curve curve,
+            final Representation repr,
+            final FieldElement X,
+            final FieldElement Y,
+            final FieldElement Z,
+            final FieldElement T) {
+        this(curve, repr, X, Y, Z, T, false);
+    }
+
+    /**
+     * Creates a group element for a curve, with optional pre-computation.
      *
      * @param curve The curve.
      * @param repr The representation used to represent the group element.
@@ -229,7 +268,7 @@ public class GroupElement implements Serializable {
     }
 
     /**
-     * Creates a group element for a curve from a given encoded point.
+     * Creates a group element for a curve from a given encoded point. No pre-computation.
      * <p>
      * A point $(x,y)$ is encoded by storing $y$ in bit 0 to bit 254 and the sign of $x$ in bit 255.
      * $x$ is recovered in the following way:
@@ -249,7 +288,7 @@ public class GroupElement implements Serializable {
     }
 
     /**
-     * Creates a group element for a curve from a given encoded point.
+     * Creates a group element for a curve from a given encoded point.  With optional pre-computation.
      * <p>
      * A point $(x,y)$ is encoded by storing $y$ in bit 0 to bit 254 and the sign of $x$ in bit 255.
      * $x$ is recovered in the following way:
@@ -265,7 +304,6 @@ public class GroupElement implements Serializable {
      * @param s The encoded point.
      * @param precomputeSingleAndDouble If true, populate both precmp and dblPrecmp, else set both to null.
      */
-    // TODO
     public GroupElement(final Curve curve, final byte[] s, boolean precomputeSingleAndDouble) {
         FieldElement x, y, yy, u, v, v3, vxx, check;
         y = curve.getField().fromByteArray(s);

--- a/src/net/i2p/crypto/eddsa/math/GroupElement.java
+++ b/src/net/i2p/crypto/eddsa/math/GroupElement.java
@@ -499,7 +499,7 @@ public class GroupElement implements Serializable {
                     case P2:
                         return p2(this.curve, this.X, this.Y, this.Z);
                     case P3:
-                        return p3(this.curve, this.X, this.Y, this.Z, this.T, false);
+                        return p3(this.curve, this.X, this.Y, this.Z, this.T);
                     case CACHED:
                         return cached(this.curve, this.Y.add(this.X), this.Y.subtract(this.X), this.Z, this.T.multiply(this.curve.get2D()));
                     default:

--- a/src/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTable.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTable.java
@@ -11,7 +11,7 @@
  */
 package net.i2p.crypto.eddsa.spec;
 
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Locale;
 
 import net.i2p.crypto.eddsa.Utils;
@@ -46,10 +46,16 @@ public class EdDSANamedCurveTable {
                     Utils.hexToBytes("5866666666666666666666666666666666666666666666666666666666666666"),
                     true)); // Precompute tables for B
 
-    private static final Hashtable<String, EdDSANamedCurveSpec> curves = new Hashtable<String, EdDSANamedCurveSpec>();
+    private static volatile HashMap<String, EdDSANamedCurveSpec> curves = new HashMap<String, EdDSANamedCurveSpec>();
+
+    private static synchronized void putCurve(String name, EdDSANamedCurveSpec curve) {
+        HashMap<String, EdDSANamedCurveSpec> newCurves = new HashMap<String, EdDSANamedCurveSpec>(curves);
+        newCurves.put(name, curve);
+        curves = newCurves;
+    }
 
     public static void defineCurve(EdDSANamedCurveSpec curve) {
-        curves.put(curve.getName().toLowerCase(Locale.ENGLISH), curve);
+        putCurve(curve.getName().toLowerCase(Locale.ENGLISH), curve);
     }
 
     static void defineCurveAlias(String name, String alias) {
@@ -57,7 +63,7 @@ public class EdDSANamedCurveTable {
         if (curve == null) {
             throw new IllegalStateException();
         }
-        curves.put(alias.toLowerCase(Locale.ENGLISH), curve);
+        putCurve(alias.toLowerCase(Locale.ENGLISH), curve);
     }
 
     static {

--- a/src/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTable.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTable.java
@@ -37,7 +37,7 @@ public class EdDSANamedCurveTable {
             Utils.hexToBytes("a3785913ca4deb75abd841414d0a700098e879777940c78c73fe6f2bee6c0352"), // d
             ed25519field.fromByteArray(Utils.hexToBytes("b0a00e4a271beec478e42fad0618432fa7d7fb3d99004d2b0bdfc14f8024832b"))); // I
 
-    private static final EdDSANamedCurveSpec ed25519 = new EdDSANamedCurveSpec(
+    public static final EdDSANamedCurveSpec ED_25519_CURVE_SPEC = new EdDSANamedCurveSpec(
             ED_25519,
             ed25519curve,
             "SHA-512", // H
@@ -68,7 +68,7 @@ public class EdDSANamedCurveTable {
 
     static {
         // RFC 8032
-        defineCurve(ed25519);
+        defineCurve(ED_25519_CURVE_SPEC);
     }
 
     public static EdDSANamedCurveSpec getByName(String name) {

--- a/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
@@ -48,7 +48,7 @@ public class EdDSAPublicKeySpec implements KeySpec {
     }
 
     public GroupElement getNegativeA() {
-        // Only read Aneg once, otherwise read re-ordering might occur between here and return.
+        // Only read Aneg once, otherwise read re-ordering might occur between here and return. Requires all GroupElement's fields to be final.
         GroupElement ourAneg = Aneg;
         if(ourAneg == null) {
             ourAneg = A.negate();

--- a/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
@@ -36,14 +36,12 @@ public class EdDSAPublicKeySpec implements KeySpec {
         this.A = new GroupElement(spec.getCurve(), pk);
         // Precompute -A for use in verification.
         this.Aneg = A.negate();
-        Aneg.precompute(false);
         this.spec = spec;
     }
 
     public EdDSAPublicKeySpec(GroupElement A, EdDSAParameterSpec spec) {
         this.A = A;
         this.Aneg = A.negate();
-        Aneg.precompute(false);
         this.spec = spec;
     }
 

--- a/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
@@ -21,7 +21,7 @@ import net.i2p.crypto.eddsa.math.GroupElement;
  */
 public class EdDSAPublicKeySpec implements KeySpec {
     private final GroupElement A;
-    private final GroupElement Aneg;
+    private GroupElement Aneg;
     private final EdDSAParameterSpec spec;
 
     /**
@@ -34,8 +34,6 @@ public class EdDSAPublicKeySpec implements KeySpec {
             throw new IllegalArgumentException("public-key length is wrong");
 
         this.A = new GroupElement(spec.getCurve(), pk);
-        // Precompute -A for use in verification.
-        this.Aneg = A.negate();
         this.spec = spec;
     }
 
@@ -50,7 +48,13 @@ public class EdDSAPublicKeySpec implements KeySpec {
     }
 
     public GroupElement getNegativeA() {
-        return Aneg;
+        // Only read Aneg once, otherwise read re-ordering might occur between here and return.
+        GroupElement ourAneg = Aneg;
+        if(ourAneg == null) {
+            ourAneg = A.negate();
+            Aneg = ourAneg;
+        }
+        return ourAneg;
     }
 
     public EdDSAParameterSpec getParams() {

--- a/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
@@ -21,7 +21,7 @@ import net.i2p.crypto.eddsa.math.GroupElement;
  */
 public class EdDSAPublicKeySpec implements KeySpec {
     private final GroupElement A;
-    private GroupElement Aneg;
+    private GroupElement Aneg = null;
     private final EdDSAParameterSpec spec;
 
     /**
@@ -39,7 +39,6 @@ public class EdDSAPublicKeySpec implements KeySpec {
 
     public EdDSAPublicKeySpec(GroupElement A, EdDSAParameterSpec spec) {
         this.A = A;
-        this.Aneg = A.negate();
         this.spec = spec;
     }
 

--- a/test/net/i2p/crypto/eddsa/math/ConstantsTest.java
+++ b/test/net/i2p/crypto/eddsa/math/ConstantsTest.java
@@ -38,7 +38,7 @@ public class ConstantsTest {
     static final FieldElement ONE = curve.getField().ONE;
     static final FieldElement TWO = curve.getField().TWO;
 
-    static final GroupElement P3_ZERO = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO);
+    static final GroupElement P3_ZERO = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO, false);
 
     @Test
     public void testb() {

--- a/test/net/i2p/crypto/eddsa/math/ConstantsTest.java
+++ b/test/net/i2p/crypto/eddsa/math/ConstantsTest.java
@@ -38,7 +38,7 @@ public class ConstantsTest {
     static final FieldElement ONE = curve.getField().ONE;
     static final FieldElement TWO = curve.getField().TWO;
 
-    static final GroupElement P3_ZERO = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO, false);
+    static final GroupElement P3_ZERO = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO);
 
     @Test
     public void testb() {

--- a/test/net/i2p/crypto/eddsa/math/GroupElementTest.java
+++ b/test/net/i2p/crypto/eddsa/math/GroupElementTest.java
@@ -68,11 +68,11 @@ public class GroupElementTest {
     }
 
     /**
-     * Test method for {@link GroupElement#p3(Curve, FieldElement, FieldElement, FieldElement, FieldElement)}.
+     * Test method for {@link GroupElement#p3(Curve, FieldElement, FieldElement, FieldElement, FieldElement, boolean)}.
      */
     @Test
     public void testP3() {
-        final GroupElement t = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO);
+        final GroupElement t = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO, false);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P3));
         assertThat(t.X, is(ZERO));
@@ -124,11 +124,11 @@ public class GroupElementTest {
     }
 
     /**
-     * Test method for {@link GroupElement#GroupElement(Curve, GroupElement.Representation, FieldElement, FieldElement, FieldElement, FieldElement)}.
+     * Test method for {@link GroupElement#GroupElement(Curve, GroupElement.Representation, FieldElement, FieldElement, FieldElement, FieldElement, boolean)}.
      */
     @Test
     public void testGroupElementCurveRepresentationFieldElementFieldElementFieldElementFieldElement() {
-        final GroupElement t = new GroupElement(curve, GroupElement.Representation.P3, ZERO, ONE, ONE, ZERO);
+        final GroupElement t = new GroupElement(curve, GroupElement.Representation.P3, ZERO, ONE, ONE, ZERO, false);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P3));
         assertThat(t.X, is(ZERO));
@@ -157,7 +157,7 @@ public class GroupElementTest {
     @Test
     public void testGroupElementByteArray() {
         final GroupElement t = new GroupElement(curve, BYTES_PKR);
-        final GroupElement s = GroupElement.p3(curve, PKR[0], PKR[1], ONE, PKR[0].multiply(PKR[1]));
+        final GroupElement s = GroupElement.p3(curve, PKR[0], PKR[1], ONE, PKR[0].multiply(PKR[1]),false);
         assertThat(t, is(equalTo(s)));
     }
 
@@ -462,7 +462,7 @@ public class GroupElementTest {
     // endregion
 
     /**
-     * Test method for {@link GroupElement#precompute(boolean)}.
+     * Test method for precomputation.
      */
     @Test
     public void testPrecompute() {
@@ -529,7 +529,7 @@ public class GroupElementTest {
 
     @Test
     public void addingNeutralGroupElementDoesNotChangeGroupElement() {
-        final GroupElement neutral = GroupElement.p3(curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO);
+        final GroupElement neutral = GroupElement.p3(curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO, false);
         for (int i=0; i<1000; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
@@ -770,8 +770,7 @@ public class GroupElementTest {
         byte[] a = Utils.hexToBytes("d072f8dd9c07fa7bc8d22a4b325d26301ee9202f6db89aa7c3731529e37e437c");
         GroupElement A = new GroupElement(curve, Utils.hexToBytes("d4cf8595571830644bd14af416954d09ab7159751ad9e0f7a6cbd92379e71a66"));
         GroupElement B = ed25519.getB();
-        GroupElement geZero = curve.getZero(GroupElement.Representation.P3);
-        geZero.precompute(false);
+        GroupElement geZero = curve.getZero(GroupElement.Representation.P3PrecomputedDouble);
 
         // 0 * GE(0) + 0 * GE(0) = GE(0)
         assertThat(geZero.doubleScalarMultiplyVariableTime(geZero, zero, zero),
@@ -812,8 +811,7 @@ public class GroupElementTest {
         for (int i=0; i<10; i++) {
             // Arrange:
             final GroupElement basePoint = ed25519.getB();
-            final GroupElement g = MathUtils.getRandomGroupElement();
-            g.precompute(false);
+            final GroupElement g = MathUtils.getRandomGroupElement(true);
             final FieldElement f1 = MathUtils.getRandomFieldElement();
             final FieldElement f2 = MathUtils.getRandomFieldElement();
 

--- a/test/net/i2p/crypto/eddsa/math/GroupElementTest.java
+++ b/test/net/i2p/crypto/eddsa/math/GroupElementTest.java
@@ -68,10 +68,24 @@ public class GroupElementTest {
     }
 
     /**
-     * Test method for {@link GroupElement#p3(Curve, FieldElement, FieldElement, FieldElement, FieldElement, boolean)}.
+     * Test method for {@link GroupElement#p3(Curve, FieldElement, FieldElement, FieldElement, FieldElement)}.
      */
     @Test
     public void testP3() {
+        final GroupElement t = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO);
+        assertThat(t.curve, is(equalTo(curve)));
+        assertThat(t.repr, is(GroupElement.Representation.P3));
+        assertThat(t.X, is(ZERO));
+        assertThat(t.Y, is(ONE));
+        assertThat(t.Z, is(ONE));
+        assertThat(t.T, is(ZERO));
+    }
+
+    /**
+     * Test method for {@link GroupElement#p3(Curve, FieldElement, FieldElement, FieldElement, FieldElement, boolean)}.
+     */
+    @Test
+    public void testP3WithExplicitFlag() {
         final GroupElement t = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO, false);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P3));
@@ -124,10 +138,24 @@ public class GroupElementTest {
     }
 
     /**
-     * Test method for {@link GroupElement#GroupElement(Curve, GroupElement.Representation, FieldElement, FieldElement, FieldElement, FieldElement, boolean)}.
+     * Test method for {@link GroupElement#GroupElement(Curve, GroupElement.Representation, FieldElement, FieldElement, FieldElement, FieldElement)}.
      */
     @Test
     public void testGroupElementCurveRepresentationFieldElementFieldElementFieldElementFieldElement() {
+        final GroupElement t = new GroupElement(curve, GroupElement.Representation.P3, ZERO, ONE, ONE, ZERO);
+        assertThat(t.curve, is(equalTo(curve)));
+        assertThat(t.repr, is(GroupElement.Representation.P3));
+        assertThat(t.X, is(ZERO));
+        assertThat(t.Y, is(ONE));
+        assertThat(t.Z, is(ONE));
+        assertThat(t.T, is(ZERO));
+    }
+
+    /**
+     * Test method for {@link GroupElement#GroupElement(Curve, GroupElement.Representation, FieldElement, FieldElement, FieldElement, FieldElement, boolean)}.
+     */
+    @Test
+    public void testGroupElementCurveRepresentationFieldElementFieldElementFieldElementFieldElementWithExplicitFlag() {
         final GroupElement t = new GroupElement(curve, GroupElement.Representation.P3, ZERO, ONE, ONE, ZERO, false);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P3));
@@ -157,7 +185,7 @@ public class GroupElementTest {
     @Test
     public void testGroupElementByteArray() {
         final GroupElement t = new GroupElement(curve, BYTES_PKR);
-        final GroupElement s = GroupElement.p3(curve, PKR[0], PKR[1], ONE, PKR[0].multiply(PKR[1]),false);
+        final GroupElement s = GroupElement.p3(curve, PKR[0], PKR[1], ONE, PKR[0].multiply(PKR[1]));
         assertThat(t, is(equalTo(s)));
     }
 
@@ -391,6 +419,29 @@ public class GroupElementTest {
         }
     }
 
+    @Test
+    public void toP3PrecomputeDoubleReturnsExpectedResultIfGroupElementHasP1P1Representation() {
+        for (int i=0; i<10; i++) {
+            // Arrange:
+            final GroupElement g = MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.P1P1);
+
+            // Act:
+            final GroupElement h1 = g.toP3PrecomputeDouble();
+            final GroupElement h2 = MathUtils.toRepresentation(g, GroupElement.Representation.P3PrecomputedDouble);
+
+            // Assert:
+            Assert.assertThat(h1, IsEqual.equalTo(h2));
+            Assert.assertThat(h1.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.P3));
+            Assert.assertThat(h1.getX(), IsEqual.equalTo(g.getX().multiply(g.getT())));
+            Assert.assertThat(h1.getY(), IsEqual.equalTo(g.getY().multiply(g.getZ())));
+            Assert.assertThat(h1.getZ(), IsEqual.equalTo(g.getZ().multiply(g.getT())));
+            Assert.assertThat(h1.getT(), IsEqual.equalTo(g.getX().multiply(g.getY())));
+            Assert.assertThat(h1.precmp, IsNull.nullValue());
+            Assert.assertThat(h1.dblPrecmp, IsNull.notNullValue());
+            Assert.assertThat(h1.dblPrecmp, IsEqual.equalTo(h2.dblPrecmp));
+        }
+    }
+
     @Test (expected = IllegalArgumentException.class)
     public void toCachedThrowsIfGroupElementHasP2Representation() {
         // Arrange:
@@ -529,7 +580,7 @@ public class GroupElementTest {
 
     @Test
     public void addingNeutralGroupElementDoesNotChangeGroupElement() {
-        final GroupElement neutral = GroupElement.p3(curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO, false);
+        final GroupElement neutral = GroupElement.p3(curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO);
         for (int i=0; i<1000; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();

--- a/test/net/i2p/crypto/eddsa/math/MathUtils.java
+++ b/test/net/i2p/crypto/eddsa/math/MathUtils.java
@@ -191,6 +191,11 @@ public class MathUtils {
      */
     public static GroupElement getRandomGroupElement() { return getRandomGroupElement(false); }
 
+    /**
+     * Gets a random group element in P3 representation, with precmp and dblPrecmp populated.
+     *
+     * @return The group element.
+     */
     public static GroupElement getRandomGroupElement(boolean precompute) {
         final byte[] bytes = new byte[32];
         while (true) {

--- a/test/net/i2p/crypto/eddsa/math/MathUtils.java
+++ b/test/net/i2p/crypto/eddsa/math/MathUtils.java
@@ -189,12 +189,14 @@ public class MathUtils {
      *
      * @return The group element.
      */
-    public static GroupElement getRandomGroupElement() {
+    public static GroupElement getRandomGroupElement() { return getRandomGroupElement(false); }
+
+    public static GroupElement getRandomGroupElement(boolean precompute) {
         final byte[] bytes = new byte[32];
         while (true) {
             try {
                 random.nextBytes(bytes);
-                return new GroupElement(curve, bytes);
+                return new GroupElement(curve, bytes, precompute);
             } catch (IllegalArgumentException e) {
                 // Will fail in about 87.5%, so try again.
             }
@@ -230,7 +232,7 @@ public class MathUtils {
             x = x.negate().mod(getQ());
         }
 
-        return GroupElement.p3(curve, toFieldElement(x), toFieldElement(y), getField().ONE, toFieldElement(x.multiply(y).mod(getQ())));
+        return GroupElement.p3(curve, toFieldElement(x), toFieldElement(y), getField().ONE, toFieldElement(x.multiply(y).mod(getQ())), false);
     }
 
     /**
@@ -286,7 +288,7 @@ public class MathUtils {
                         toFieldElement(x),
                         toFieldElement(y),
                         getField().ONE,
-                        toFieldElement(x.multiply(y).mod(getQ())));
+                        toFieldElement(x.multiply(y).mod(getQ())), false);
             case P1P1:
                 return GroupElement.p1p1(
                         curve,
@@ -356,7 +358,7 @@ public class MathUtils {
                 .multiply(BigInteger.ONE.subtract(dx1x2y1y2).modInverse(getQ())).mod(getQ());
         BigInteger t3 = x3.multiply(y3).mod(getQ());
 
-        return GroupElement.p3(g1.getCurve(), toFieldElement(x3), toFieldElement(y3), getField().ONE, toFieldElement(t3));
+        return GroupElement.p3(g1.getCurve(), toFieldElement(x3), toFieldElement(y3), getField().ONE, toFieldElement(t3), false);
     }
 
     /**
@@ -421,13 +423,13 @@ public class MathUtils {
             throw new IllegalArgumentException("g must have representation P3");
         }
 
-        return GroupElement.p3(g.getCurve(), g.getX().negate(), g.getY(), g.getZ(), g.getT().negate());
+        return GroupElement.p3(g.getCurve(), g.getX().negate(), g.getY(), g.getZ(), g.getT().negate(), false);
     }
 
     // Start TODO BR: Remove when finished!
     @Test
     public void mathUtilsWorkAsExpected() {
-        final GroupElement neutral = GroupElement.p3(curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO);
+        final GroupElement neutral = GroupElement.p3(curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO, false);
         for (int i=0; i<1000; i++) {
             final GroupElement g = getRandomGroupElement();
 

--- a/test/net/i2p/crypto/eddsa/math/MathUtils.java
+++ b/test/net/i2p/crypto/eddsa/math/MathUtils.java
@@ -260,6 +260,7 @@ public class MathUtils {
         switch (g.getRepresentation()) {
             case P2:
             case P3:
+            case P3PrecomputedDouble:
                 x = gX.multiply(gZ.modInverse(getQ())).mod(getQ());
                 y = gY.multiply(gZ.modInverse(getQ())).mod(getQ());
                 break;
@@ -294,6 +295,13 @@ public class MathUtils {
                         toFieldElement(y),
                         getField().ONE,
                         toFieldElement(x.multiply(y).mod(getQ())), false);
+            case P3PrecomputedDouble:
+                return GroupElement.p3(
+                        curve,
+                        toFieldElement(x),
+                        toFieldElement(y),
+                        getField().ONE,
+                        toFieldElement(x.multiply(y).mod(getQ())), true);
             case P1P1:
                 return GroupElement.p1p1(
                         curve,

--- a/test/net/i2p/crypto/eddsa/math/MathUtils.java
+++ b/test/net/i2p/crypto/eddsa/math/MathUtils.java
@@ -237,7 +237,7 @@ public class MathUtils {
             x = x.negate().mod(getQ());
         }
 
-        return GroupElement.p3(curve, toFieldElement(x), toFieldElement(y), getField().ONE, toFieldElement(x.multiply(y).mod(getQ())), false);
+        return GroupElement.p3(curve, toFieldElement(x), toFieldElement(y), getField().ONE, toFieldElement(x.multiply(y).mod(getQ())));
     }
 
     /**
@@ -371,7 +371,7 @@ public class MathUtils {
                 .multiply(BigInteger.ONE.subtract(dx1x2y1y2).modInverse(getQ())).mod(getQ());
         BigInteger t3 = x3.multiply(y3).mod(getQ());
 
-        return GroupElement.p3(g1.getCurve(), toFieldElement(x3), toFieldElement(y3), getField().ONE, toFieldElement(t3), false);
+        return GroupElement.p3(g1.getCurve(), toFieldElement(x3), toFieldElement(y3), getField().ONE, toFieldElement(t3));
     }
 
     /**
@@ -436,13 +436,13 @@ public class MathUtils {
             throw new IllegalArgumentException("g must have representation P3");
         }
 
-        return GroupElement.p3(g.getCurve(), g.getX().negate(), g.getY(), g.getZ(), g.getT().negate(), false);
+        return GroupElement.p3(g.getCurve(), g.getX().negate(), g.getY(), g.getZ(), g.getT().negate());
     }
 
     // Start TODO BR: Remove when finished!
     @Test
     public void mathUtilsWorkAsExpected() {
-        final GroupElement neutral = GroupElement.p3(curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO, false);
+        final GroupElement neutral = GroupElement.p3(curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO);
         for (int i=0; i<1000; i++) {
             final GroupElement g = getRandomGroupElement();
 

--- a/test/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTableTest.java
+++ b/test/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTableTest.java
@@ -11,6 +11,7 @@
  */
 package net.i2p.crypto.eddsa.spec;
 
+import static net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable.ED_25519;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -32,5 +33,11 @@ public class EdDSANamedCurveTableTest {
 
         assertThat(lower, is(equalTo(mixed)));
         assertThat(upper, is(equalTo(mixed)));
+    }
+
+    @Test
+    public void testConstant() {
+        EdDSANamedCurveSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
+        assertThat("Named curve and constant should match", spec, is(equalTo(ED_25519)));
     }
 }

--- a/test/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTableTest.java
+++ b/test/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTableTest.java
@@ -12,6 +12,7 @@
 package net.i2p.crypto.eddsa.spec;
 
 import static net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable.ED_25519;
+import static net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable.ED_25519_CURVE_SPEC;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -36,8 +37,8 @@ public class EdDSANamedCurveTableTest {
     }
 
     @Test
-    public void testConstant() {
-        EdDSANamedCurveSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
-        assertThat("Named curve and constant should match", spec, is(equalTo(ED_25519)));
+    public void testConstants() {
+        EdDSANamedCurveSpec spec = EdDSANamedCurveTable.getByName(ED_25519);
+        assertThat("Named curve and constant should match", spec, is(equalTo(ED_25519_CURVE_SPEC)));
     }
 }


### PR DESCRIPTION
1. Make `GroupElement` immutable by moving the pre-computed logic to the constructors, allowing the synchronized checking of whether the pre-computed logic had executed or not to be removed since it always has when it is used because those code paths are modified to request it at construction time.
2. This allows `getNegativeA()` to be lazy, and doesn't need volatile due to the immutability (and final fields - this is important part of the contract with the JVM memory model).
3. Remove synchronized contention from the named curve table get method.
4. Generally remove use of the named curve table get method with a constant curve name in hot code paths in favour of using a new static constant for the curve spec.
5. Some changes to support JitPack builds.