### PR TITLE
Fixes #61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /bin/
 /target/
 /.settings/
+/.idea/
 *.class
 *.iml

--- a/src/net/i2p/crypto/eddsa/math/Encoding.java
+++ b/src/net/i2p/crypto/eddsa/math/Encoding.java
@@ -11,13 +11,15 @@
  */
 package net.i2p.crypto.eddsa.math;
 
+import java.io.Serializable;
+
 /**
  * Common interface for all $(b-1)$-bit encodings of elements
  * of EdDSA finite fields.
  * @author str4d
  *
  */
-public abstract class Encoding {
+public abstract class Encoding implements Serializable {
     protected Field f;
 
     public synchronized void setField(Field f) {

--- a/src/net/i2p/crypto/eddsa/math/ScalarOps.java
+++ b/src/net/i2p/crypto/eddsa/math/ScalarOps.java
@@ -11,7 +11,9 @@
  */
 package net.i2p.crypto.eddsa.math;
 
-public interface ScalarOps {
+import java.io.Serializable;
+
+public interface ScalarOps extends Serializable {
     /**
      * Reduce the given scalar mod $l$.
      * <p>

--- a/test/net/i2p/crypto/eddsa/EdDSAPublicKeyTest.java
+++ b/test/net/i2p/crypto/eddsa/EdDSAPublicKeyTest.java
@@ -16,10 +16,15 @@ import static org.junit.Assert.*;
 
 import java.security.spec.X509EncodedKeySpec;
 
-import net.i2p.crypto.eddsa.Utils;
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
 
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.security.spec.InvalidKeySpecException;
 
 /**
  * @author str4d
@@ -81,5 +86,29 @@ public class EdDSAPublicKeyTest {
 
         // Check
         assertThat(keyOut.getEncoded(), is(equalTo(TEST_PUBKEY)));
+    }
+
+    @Test
+    public void testJavaSerialization() throws InvalidKeySpecException {
+        final X509EncodedKeySpec encoded = new X509EncodedKeySpec(TEST_PUBKEY_OLD);
+        final EdDSAPublicKey keyOut = new EdDSAPublicKey(encoded);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
+        try {
+            final ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(keyOut);
+            oos.flush();
+            oos.close();
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Failed to serialize object of type: " + keyOut.getClass(), ex);
+        }
+
+        try {
+            final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+            final EdDSAPublicKey keyIn = (EdDSAPublicKey) ois.readObject();
+            assertThat(keyIn, is(keyOut));
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Failed to deserialize object", ex);
+        }
     }
 }


### PR DESCRIPTION
Fixes #61

* Add `java.io.Serializable` interface to `EdDSAPublicKey` and `EdDSAPrivateKey` class heirarchies.
* Add Java Serialization unit test coverage for `EdDSAPublicKey` and `EdDSAPrivateKey`.

Signed-off-by: sappenin <sappenin@gmail.com>