### PR TITLE
Throw IAE if Utils.hexToBytes() is given an odd-length string

### DIFF
--- a/src/net/i2p/crypto/eddsa/Utils.java
+++ b/src/net/i2p/crypto/eddsa/Utils.java
@@ -75,6 +75,9 @@ public class Utils {
      */
     public static byte[] hexToBytes(String s) {
         int len = s.length();
+        if (len % 2 != 0) {
+            throw new IllegalArgumentException("Hex string must have an even length");
+        }
         byte[] data = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {
             data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)

--- a/test/net/i2p/crypto/eddsa/UtilsTest.java
+++ b/test/net/i2p/crypto/eddsa/UtilsTest.java
@@ -116,6 +116,11 @@ public class UtilsTest {
         assertThat(Utils.bit(new byte[] {1, 2, 3}, 16), is(1));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void hexToBytesThrowsOnInvalidLengthHexString() {
+        Utils.hexToBytes("bad");
+    }
+
     @Test
     public void hexToBytesReturnsCorrectByteArray() {
         Assert.assertThat(Utils.hexToBytes(hex1), IsEqual.equalTo(bytes1));


### PR DESCRIPTION
CLoses #70.