### PR TITLE
Update encoding documentation to reference RFC 8410

### DIFF
--- a/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
@@ -23,19 +23,15 @@ import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
 
 /**
  * An EdDSA private key.
- *<p>
- * Warning: Private key encoding is based on the current curdle WG draft,
- * and is subject to change. See getEncoded().
- *</p><p>
- * For compatibility with older releases, decoding supports both the old and new
- * draft specifications. See decode().
- *</p><p>
- * Ref: https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
- *</p><p>
- * Old Ref: https://tools.ietf.org/html/draft-josefsson-pkix-eddsa-04
- *</p>
- * @author str4d
+ * <p>
+ * For compatibility with older releases, decoding supports both RFC 8410 and an
+ * older draft specifications.
  *
+ * @author str4d
+ * @see <a href="https://tools.ietf.org/html/rfc8410">RFC 8410</a>
+ * @see <a href=
+ *      "https://tools.ietf.org/html/draft-josefsson-pkix-eddsa-04">Older draft
+ *      specification</a>
  */
 public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
     private static final long serialVersionUID = 23495873459878957L;
@@ -77,60 +73,60 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
     }
 
     /**
-     * Returns the public key in its canonical encoding.
-     *<p>
+     * Returns the private key in its canonical encoding.
+     * <p>
      * This implements the following specs:
-     *<ul><li>
-     * General encoding: https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
-     *</li><li>
-     * Key encoding: https://tools.ietf.org/html/rfc8032
-     *</li></ul>
-     *<p>
-     * This encodes the seed. It will return null if constructed from
-     * a spec which was directly constructed from H, in which case seed is null.
-     *</p><p>
+     * <ul>
+     * <li>General encoding: https://tools.ietf.org/html/rfc8410</li>
+     * <li>Key encoding: https://tools.ietf.org/html/rfc8032</li>
+     * </ul>
+     * <p>
+     * This encodes the seed. It will return null if constructed from a spec which
+     * was directly constructed from H, in which case seed is null.
+     * <p>
      * For keys in older formats, decoding and then re-encoding is sufficient to
      * migrate them to the canonical encoding.
-     *</p>
+     * <p>
      * Relevant spec quotes:
-     *<pre>
+     *
+     * <pre>
      *  OneAsymmetricKey ::= SEQUENCE {
      *    version Version,
      *    privateKeyAlgorithm PrivateKeyAlgorithmIdentifier,
      *    privateKey PrivateKey,
-     *    attributes [0] Attributes OPTIONAL,
+     *    attributes [0] IMPLICIT Attributes OPTIONAL,
      *    ...,
-     *    [[2: publicKey [1] PublicKey OPTIONAL ]],
+     *    [[2: publicKey [1] IMPLICIT PublicKey OPTIONAL ]],
      *    ...
      *  }
      *
      *  Version ::= INTEGER
      *  PrivateKeyAlgorithmIdentifier ::= AlgorithmIdentifier
      *  PrivateKey ::= OCTET STRING
-     *  PublicKey ::= OCTET STRING
+     *  PublicKey ::= BIT STRING
      *  Attributes ::= SET OF Attribute
-     *</pre>
+     * </pre>
      *
-     *<pre>
+     * <pre>
      *  ... when encoding a OneAsymmetricKey object, the private key is wrapped
      *  in a CurvePrivateKey object and wrapped by the OCTET STRING of the
-     *  'privateKey' field.
+     *  "privateKey" field.
      *
      *  CurvePrivateKey ::= OCTET STRING
-     *</pre>
+     * </pre>
      *
-     *<pre>
+     * <pre>
      *  AlgorithmIdentifier  ::=  SEQUENCE  {
      *    algorithm   OBJECT IDENTIFIER,
      *    parameters  ANY DEFINED BY algorithm OPTIONAL
      *  }
      *
      *  For all of the OIDs, the parameters MUST be absent.
-     *</pre>
+     * </pre>
      *
-     *<pre>
+     * <pre>
      *  id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }
-     *</pre>
+     * </pre>
      *
      * @return 48 bytes for Ed25519, null for other curves
      */
@@ -176,17 +172,15 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
 
     /**
      * Extracts the private key bytes from the provided encoding.
-     *<p>
-     * This will decode data conforming to the current spec at
-     * https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
-     * or as inferred from the old spec at
-     * https://tools.ietf.org/html/draft-josefsson-pkix-eddsa-04.
-     *</p><p>
-     * Contrary to draft-ietf-curdle-pkix-04, it WILL accept a parameter value
-     * of NULL, as it is required for interoperability with the default Java
-     * keystore. Other implementations MUST NOT copy this behaviour from here
-     * unless they also need to read keys from the default Java keystore.
-     *</p><p>
+     * <p>
+     * This will decode data conforming to RFC 8410 or as inferred from the older
+     * draft spec at https://tools.ietf.org/html/draft-josefsson-pkix-eddsa-04.
+     * <p>
+     * Per RFC 8410 section 3, this function WILL accept a parameter value of
+     * NULL, as it is required for interoperability with the default Java keystore.
+     * Other implementations MUST NOT copy this behaviour from here unless they also
+     * need to read keys from the default Java keystore.
+     * <p>
      * This is really dumb for now. It does not use a general-purpose ASN.1 decoder.
      * See also getEncoded().
      *
@@ -248,13 +242,18 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
             } else {
                 // Handle parameter value of NULL
                 //
-                // Quote https://tools.ietf.org/html/draft-ietf-curdle-pkix-04 :
-                //   For all of the OIDs, the parameters MUST be absent.
-                //   Regardless of the defect in the original 1997 syntax,
-                //   implementations MUST NOT accept a parameters value of NULL.
+                // Quoting RFC 8410 section 3:
+                // > For all of the OIDs, the parameters MUST be absent.
+                // >
+                // > It is possible to find systems that require the parameters to be
+                // > present. This can be due to either a defect in the original 1997
+                // > syntax or a programming error where developers never got input where
+                // > this was not true. The optimal solution is to fix these systems;
+                // > where this is not possible, the problem needs to be restricted to
+                // > that subsystem and not propagated to the Internet.
                 //
-                // But Java's default keystore puts it in (when decoding as
-                // PKCS8 and then re-encoding to pass on), so we must accept it.
+                // Java's default keystore puts it in (when decoding as PKCS8 and then
+                // re-encoding to pass on), so we must accept it.
                 if (idlen == 7) {
                     if (d[idx++] != 0x05 ||
                         d[idx++] != 0) {
@@ -285,36 +284,36 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
     }
 
     /**
-     *  @return will be null if constructed from a spec which was
-     *          directly constructed from H
+     * @return will be null if constructed from a spec which was directly
+     *         constructed from H
      */
     public byte[] getSeed() {
         return seed;
     }
 
     /**
-     *  @return the hash of the seed
+     * @return the hash of the seed
      */
     public byte[] getH() {
         return h;
     }
 
     /**
-     *  @return the private key
+     * @return the private key
      */
     public byte[] geta() {
         return a;
     }
 
     /**
-     *  @return the public key
+     * @return the public key
      */
     public GroupElement getA() {
         return A;
     }
 
     /**
-     *  @return the public key
+     * @return the public key
      */
     public byte[] getAbyte() {
         return Abyte;

--- a/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
@@ -23,19 +23,15 @@ import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
 
 /**
  * An EdDSA public key.
- *<p>
- * Warning: Public key encoding is is based on the current curdle WG draft,
- * and is subject to change. See getEncoded().
- *</p><p>
- * For compatibility with older releases, decoding supports both the old and new
- * draft specifications. See decode().
- *</p><p>
- * Ref: https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
- *</p><p>
- * Old Ref: https://tools.ietf.org/html/draft-josefsson-pkix-eddsa-04
- *</p>
- * @author str4d
+ * <p>
+ * For compatibility with older releases, decoding supports both RFC 8410 and an
+ * older draft specification.
  *
+ * @author str4d
+ * @see <a href="https://tools.ietf.org/html/rfc8410">RFC 8410</a>
+ * @see <a href=
+ *      "https://tools.ietf.org/html/draft-josefsson-pkix-eddsa-04">Older draft
+ *      specification</a>
  */
 public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     private static final long serialVersionUID = 9837459837498475L;
@@ -73,19 +69,19 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
 
     /**
      * Returns the public key in its canonical encoding.
-     *<p>
+     * <p>
      * This implements the following specs:
-     *<ul><li>
-     * General encoding: https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
-     *</li><li>
-     * Key encoding: https://tools.ietf.org/html/rfc8032
-     *</li></ul>
-     *<p>
+     * <ul>
+     * <li>General encoding: https://tools.ietf.org/html/rfc8410</li>
+     * <li>Key encoding: https://tools.ietf.org/html/rfc8032</li>
+     * </ul>
+     * <p>
      * For keys in older formats, decoding and then re-encoding is sufficient to
      * migrate them to the canonical encoding.
-     *</p>
+     * <p>
      * Relevant spec quotes:
-     *<pre>
+     *
+     * <pre>
      *  In the X.509 certificate, the subjectPublicKeyInfo field has the
      *  SubjectPublicKeyInfo type, which has the following ASN.1 syntax:
      *
@@ -93,20 +89,20 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
      *    algorithm         AlgorithmIdentifier,
      *    subjectPublicKey  BIT STRING
      *  }
-     *</pre>
+     * </pre>
      *
-     *<pre>
+     * <pre>
      *  AlgorithmIdentifier  ::=  SEQUENCE  {
      *    algorithm   OBJECT IDENTIFIER,
      *    parameters  ANY DEFINED BY algorithm OPTIONAL
      *  }
      *
      *  For all of the OIDs, the parameters MUST be absent.
-     *</pre>
+     * </pre>
      *
-     *<pre>
+     * <pre>
      *  id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }
-     *</pre>
+     * </pre>
      *
      * @return 44 bytes for Ed25519, null for other curves
      */
@@ -142,20 +138,17 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
 
     /**
      * Extracts the public key bytes from the provided encoding.
-     *<p>
-     * This will decode data conforming to the current spec at
-     * https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
-     * or the old spec at
+     * <p>
+     * This will decode data conforming to RFC 8410 or the older draft spec at
      * https://tools.ietf.org/html/draft-josefsson-pkix-eddsa-04.
-     *</p><p>
-     * Contrary to draft-ietf-curdle-pkix-04, it WILL accept a parameter value
-     * of NULL, as it is required for interoperability with the default Java
-     * keystore. Other implementations MUST NOT copy this behaviour from here
-     * unless they also need to read keys from the default Java keystore.
-     *</p><p>
+     * <p>
+     * Per RFC 8410 section 3, this function WILL accept a parameter value of
+     * NULL, as it is required for interoperability with the default Java keystore.
+     * Other implementations MUST NOT copy this behaviour from here unless they also
+     * need to read keys from the default Java keystore.
+     * <p>
      * This is really dumb for now. It does not use a general-purpose ASN.1 decoder.
      * See also getEncoded().
-     *</p>
      *
      * @return 32 bytes for Ed25519, throws for other curves
      */
@@ -212,13 +205,18 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
             } else {
                 // Handle parameter value of NULL
                 //
-                // Quote https://tools.ietf.org/html/draft-ietf-curdle-pkix-04 :
-                //   For all of the OIDs, the parameters MUST be absent.
-                //   Regardless of the defect in the original 1997 syntax,
-                //   implementations MUST NOT accept a parameters value of NULL.
+                // Quoting RFC 8410 section 3:
+                // > For all of the OIDs, the parameters MUST be absent.
+                // >
+                // > It is possible to find systems that require the parameters to be
+                // > present. This can be due to either a defect in the original 1997
+                // > syntax or a programming error where developers never got input where
+                // > this was not true. The optimal solution is to fix these systems;
+                // > where this is not possible, the problem needs to be restricted to
+                // > that subsystem and not propagated to the Internet.
                 //
-                // But Java's default keystore puts it in (when decoding as
-                // PKCS8 and then re-encoding to pass on), so we must accept it.
+                // Java's default keystore puts it in (when decoding as PKCS8 and then
+                // re-encoding to pass on), so we must accept it.
                 if (idlen == 7) {
                     if (d[idx++] != 0x05 ||
                         d[idx++] != 0) {
@@ -249,7 +247,8 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     }
 
     public GroupElement getNegativeA() {
-        // Only read Aneg once, otherwise read re-ordering might occur between here and return. Requires all GroupElement's fields to be final.
+        // Only read Aneg once, otherwise read re-ordering might occur between
+        // here and return. Requires all GroupElement's fields to be final.
         GroupElement ourAneg = Aneg;
         if(ourAneg == null) {
             ourAneg = A.negate();

--- a/src/net/i2p/crypto/eddsa/EdDSASecurityProvider.java
+++ b/src/net/i2p/crypto/eddsa/EdDSASecurityProvider.java
@@ -47,7 +47,7 @@ public class EdDSASecurityProvider extends Provider {
         // See section "Mapping from OID to name".
         // The Key* -> OID mappings correspond to the default algorithm in KeyPairGenerator.
         //
-        // From draft-ieft-curdle-pkix-04:
+        // From RFC 8410 section 3:
         //   id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }
         put("Alg.Alias.KeyFactory.1.3.101.112", EdDSAKey.KEY_ALGORITHM);
         put("Alg.Alias.KeyFactory.OID.1.3.101.112", EdDSAKey.KEY_ALGORITHM);

--- a/test/net/i2p/crypto/eddsa/EdDSAPrivateKeyTest.java
+++ b/test/net/i2p/crypto/eddsa/EdDSAPrivateKeyTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class EdDSAPrivateKeyTest {
     /**
      * The example private key MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC
-     * from https://tools.ietf.org/html/draft-ietf-curdle-pkix-04#section-10.3
+     * from https://tools.ietf.org/html/rfc8410#section-10.3
      */
     static final byte[] TEST_PRIVKEY = Utils.hexToBytes("302e020100300506032b657004220420d4ee72dbf913584ad5b6d8f1f769f8ad3afe7c28cbf1d4fbe097a88f44755842");
 

--- a/test/net/i2p/crypto/eddsa/EdDSAPublicKeyTest.java
+++ b/test/net/i2p/crypto/eddsa/EdDSAPublicKeyTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class EdDSAPublicKeyTest {
     /**
      * The example public key MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
-     * from https://tools.ietf.org/html/draft-ietf-curdle-pkix-04#section-10.1
+     * from https://tools.ietf.org/html/rfc8410#section-10.1
      */
     static final byte[] TEST_PUBKEY = Utils.hexToBytes("302a300506032b657003210019bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1");
 


### PR DESCRIPTION
This does not add support for private keys that contain attributes or the corresponding public key.