### PR TITLE
Add net.i2p.crpyto.eddsa.math to OSGi exported packages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
           <instructions>
             <Export-Package>
               net.i2p.crypto.eddsa,
+              net.i2p.crypto.eddsa.math,
               net.i2p.crypto.eddsa.spec
             </Export-Package>
             <Private-Package>


### PR DESCRIPTION
We need to export the `math` package so that we can use the `Curve` field exposed by the public `EdDSAParameterSpec` class inside an OSGi framework.