### PR TITLE
Add module-info

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - oraclejdk8
+  - oraclejdk9

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,32 @@
         <version>3.8.0</version>
       </plugin>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.Final</version>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <jvmVersion>9</jvmVersion>
+              <module>
+                <moduleInfo>
+                  <name>net.i2p.crypto.eddsa</name>
+                  <exports>
+                    net.i2p.crypto.eddsa;
+                    net.i2p.crypto.eddsa.spec;
+                  </exports>
+                </moduleInfo>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M3</version>


### PR DESCRIPTION
This uses the maven moditect plugin to add a module-info to the library as a multi-release jar.

This is needed for this to be used with jlink without manual configuration and for downstream dependencies to do the same

## Before

![fail](https://github.com/str4d/ed25519-java/assets/5004262/747722bb-fa00-4563-a6a4-f5160314a02a)


## After


![demo](https://github.com/str4d/ed25519-java/assets/5004262/dd3ff0f3-2d6a-40b8-a352-06534af11f2e)


